### PR TITLE
Change price text styles

### DIFF
--- a/src/core/plans.js
+++ b/src/core/plans.js
@@ -3,7 +3,7 @@ import { find } from 'lodash/collection';
 export const plans = [
   {
     id: 'small',
-    price: '¥50,000/月',
+    price: '50,000',
     retention: '10d',
     retentionText: '10日',
     storage: '10GB',
@@ -11,7 +11,7 @@ export const plans = [
   },
   {
     id: 'medium',
-    price: '¥300,000/月',
+    price: '300,000',
     retention: '40d',
     retentionText: '40日',
     title: 'Mediumプラン',
@@ -19,7 +19,7 @@ export const plans = [
   },
   {
     id: 'large',
-    price: '¥50,0000/月',
+    price: '500,000',
     retention: '400d',
     retentionText: '400日',
     storage: '100GB',

--- a/src/views/components/plan-card/index.css
+++ b/src/views/components/plan-card/index.css
@@ -1,0 +1,44 @@
+.whole {
+  margin-bottom: 10px;
+  cursor: pointer;
+  background-color: white;
+  text-align: center;
+}
+
+.whole-with-hover {
+  margin-bottom: 10px;
+  cursor: pointer;
+  background-color: white;
+  text-align: center;
+}
+
+.whole-with-hover:hover {
+  background-color: rgb(255, 235, 100);
+}
+
+.title {
+  font-size: 0.9rem;
+  padding: 10px;
+  border-bottom: 1px solid var(--borderColor);
+}
+
+.body {
+  padding: 20px 0 10px 0;
+}
+
+.price {
+  font-size: 1.3rem;
+  color: var(--primary2Color);
+  margin-right: 5px;
+}
+
+.attrs {
+  text-align: left;
+  margin: 20px auto 0 auto;
+  width: 160px;
+  font-size: 0.8rem;
+}
+
+.attrs > li {
+  list-style-type: none;
+}

--- a/src/views/components/plan-card/index.jsx
+++ b/src/views/components/plan-card/index.jsx
@@ -1,0 +1,51 @@
+import React, { PropTypes } from 'react';
+import { Card, CardText, CardActions } from 'material-ui/Card';
+const cardStyle = { backgroundColor: 'none' };
+
+import styles from './index.css';
+
+const PlanCard = ({ plan, onClickPlan, hover, footer }) => (
+  <div>
+    <Card
+      key={`setup-plan-${plan.id}`}
+      className={styles[hover ? 'whole-with-hover' : 'whole']}
+      style={cardStyle}
+    >
+      <CardText style={{ padding: 0 }} onClick={() => { onClickPlan(plan.id); }}>
+        <div className={styles.title}>
+          {plan.title}
+        </div>
+        <div className={styles.body}>
+          <div>
+            <span className={styles.price}>¥{plan.price}</span>
+             / 月 (税抜)
+          </div>
+          <ul className={styles.attrs}>
+            <li>{`データ保存期間: ${plan.retentionText}`}</li>
+            <li>{`ストレージ: ${plan.storage}`}</li>
+          </ul>
+        </div>
+        {footer ?
+          <CardActions>
+            {footer}
+          </CardActions>
+          : null
+        }
+      </CardText>
+    </Card>
+  </div>
+);
+
+
+PlanCard.propTypes = {
+  plan: PropTypes.object.isRequired,
+  onClickPlan: PropTypes.func.isRequired,
+  hover: PropTypes.bool,
+  footer: PropTypes.object,
+};
+
+PlanCard.defaultProps = {
+  onClickPlan: () => {},
+};
+
+export default PlanCard;

--- a/src/views/pages/dashboard/plan/index.css
+++ b/src/views/pages/dashboard/plan/index.css
@@ -18,3 +18,7 @@
 .body {
   padding: 15px;
 }
+
+.price {
+  margin-right: 3px;
+}

--- a/src/views/pages/dashboard/plan/index.jsx
+++ b/src/views/pages/dashboard/plan/index.jsx
@@ -26,7 +26,10 @@ const Plan = ({ planId }) => {
                     <TableRow>
                       <TableRowColumn>月額</TableRowColumn>
                       <TableRowColumn>
-                        <strong>{plan.price}</strong>
+                        <strong>
+                          <span className={styles.price}>¥{plan.price}</span>
+                           / 月 (税抜)
+                        </strong>
                       </TableRowColumn>
                     </TableRow>
                     <TableRow>

--- a/src/views/pages/setup/payment/index.jsx
+++ b/src/views/pages/setup/payment/index.jsx
@@ -12,8 +12,8 @@ import FlatButton from 'material-ui/FlatButton';
 import RaisedButton from 'material-ui/RaisedButton';
 import { Card, CardHeader, CardText, CardActions } from 'material-ui/Card';
 import LinearProgress from 'material-ui/LinearProgress';
-
 import Header from 'src/views/components/header-auth';
+import PlanCard from 'src/views/components/plan-card';
 import { Stripe } from 'src/core/stripe';
 import { findPlan, setupActions, getSetup } from 'src/core/setup';
 import ErrorSnackbar from 'src/views/components/error-snackbar';
@@ -45,28 +45,15 @@ const Payment = ({ setup, onSubmit, onMessageClose }) => {
               </div>
               <div className={styles.body}>
                 <div className={styles.plan}>
-                  <Card
-                    key={`setup-plan-${plan.id}`} className={styles['plan-item']}
-                  >
-                    <CardHeader
-                      title={plan.title}
-                      subtitle={`${plan.price}`}
-                    />
-                    <CardText>
-                      <span className={styles['plan-attr']}>
-                        {`データ保存期間: ${plan.retentionText}`}
-                      </span>
-                      <span className={styles['plan-attr']}>
-                        {`ストレージ: ${plan.storage}`}
-                      </span>
-                    </CardText>
-                    <CardActions>
+                  <PlanCard
+                    plan={plan}
+                    footer={
                       <FlatButton
                         label="プランを変更" secondary
                         onClick={() => { history.replace('/setup/plan'); }}
                       />
-                    </CardActions>
-                  </Card>
+                    }
+                  />
                 </div>
                 <div className={styles.payment}>
                   <div className={styles.message}>

--- a/src/views/pages/setup/plan/index.css
+++ b/src/views/pages/setup/plan/index.css
@@ -16,19 +16,3 @@
   composes: sub-text from '../../../common.css';
   margin-bottom: 20px;
 }
-
-.plan-item {
-  margin-bottom: 10px;
-  cursor: pointer;
-  background-color: white;
-}
-
-.plan-attr {
-  margin-right: 15px;
-  font-size: 0.8rem;
-}
-
-.plan-item:hover {
-  background-color: rgb(255, 235, 100);
-  /*background-color: rgb(255, 255, 200);*/
-}

--- a/src/views/pages/setup/plan/index.jsx
+++ b/src/views/pages/setup/plan/index.jsx
@@ -4,12 +4,14 @@ import { hashHistory as history } from 'react-router';
 
 import { Grid, Row, Col } from 'react-flexbox-grid/lib/index';
 import Paper from 'material-ui/Paper';
-import { Card, CardHeader, CardText } from 'material-ui/Card';
+// import { Card, CardText } from 'material-ui/Card';
 
 import Header from 'src/views/components/header-auth';
+import PlanCard from 'src/views/components/plan-card';
 import { plans, setupActions } from 'src/core/setup';
+
 import styles from './index.css';
-const cardStyle = { backgroundColor: 'none' };
+// const cardStyle = { backgroundColor: 'none' };
 
 const Plan = ({ onClickPlan }) => (
   <div>
@@ -32,23 +34,11 @@ const Plan = ({ onClickPlan }) => (
               </div>
               <div>
                 {plans.map(plan => (
-                  <Card
-                    key={`setup-plan-${plan.id}`} className={styles['plan-item']} style={cardStyle}
-                  >
-                    <CardHeader
-                      title={plan.title}
-                      subtitle={plan.price}
-                      onClick={() => { onClickPlan(plan.id); }}
-                    />
-                    <CardText>
-                      <span className={styles['plan-attr']}>
-                        {`データ保存期間: ${plan.retentionText}`}
-                      </span>
-                      <span className={styles['plan-attr']}>
-                        {`ストレージ: ${plan.storage}`}
-                      </span>
-                    </CardText>
-                  </Card>
+                  <PlanCard
+                    plan={plan}
+                    hover
+                    onClickPlan={() => { onClickPlan(plan.id); }}
+                  />
                 ))}
               </div>
             </div>


### PR DESCRIPTION
画面でプランを表示する場所を変更しました。

- style変更
- `(税抜)`を表示

<img width="500" alt="plan_text1" src="https://cloud.githubusercontent.com/assets/4277693/20780425/2d876b7c-b7be-11e6-9962-ab9c726a2993.png">

<img width="500" alt="plan_text2" src="https://cloud.githubusercontent.com/assets/4277693/20780429/31e700f6-b7be-11e6-93a0-2ba65937d309.png">

Closes https://github.com/orangesys/app.orangesys.io/issues/39
