### PR TITLE
Remove telegraf data saving logic

### DIFF
--- a/src/core/auth/index.js
+++ b/src/core/auth/index.js
@@ -61,6 +61,13 @@ export function fetchAuth() {
   ));
 }
 
+export function executeFetchAuth() {
+  return fetchAuth()
+    .then(user => ({ user }))
+    .catch(error => ({ error }));
+}
+
+
 export function initAuth(dispatch) {
   return fetchAuth()
     .then((user) => {

--- a/src/core/setup/database.js
+++ b/src/core/setup/database.js
@@ -58,13 +58,3 @@ export function updateServerSetupStatusToCompleted(uid) {
   };
   firebaseDB.ref().update(updates);
 }
-
-export function saveTelegrafToDB(uid, { consumerId, token }) {
-  const key = `users/${uid}`;
-  const updates = {
-    [`${key}/telegraf/consumerId`]: consumerId,
-    [`${key}/telegraf/token`]: token,
-    [`${key}/updatedAt`]: moment().utc().format(),
-  };
-  firebaseDB.ref().update(updates);
-}


### PR DESCRIPTION
Client Sideで、Orange APIに `/create`リクエストした後にレスポンスのtelegrafデータをDBに保存するという処理が残っていたので削除しました。

@gavinzhou 
Realtime Databaseに`telegraf`のデータを保存するのは基本的にServer Sideでやる形に変更になったのでClient Sideでは不要で良かったですよね？
理解が違ってたらすみません 😓 