### PR TITLE
Membership cancellation

### DIFF
--- a/src/core/common-info.js
+++ b/src/core/common-info.js
@@ -1,0 +1,2 @@
+/* eslint-disable no-undef */
+export const supportEmail = SUPPORT_EMAIL || 'support@orangesys.io';

--- a/src/core/dashboard/actions.js
+++ b/src/core/dashboard/actions.js
@@ -1,0 +1,5 @@
+import { createAction } from 'redux-act';
+
+export const confirmPlanCancel = createAction('confirm plan cancel');
+export const cancelPlanCancel = createAction('cancel plan cancel');
+export const cancelPlan = createAction('cancel plan');

--- a/src/core/dashboard/index.js
+++ b/src/core/dashboard/index.js
@@ -1,3 +1,7 @@
+import * as dashboardActions from './actions';
+export { dashboardActions };
+export { dashboardReducer } from './reducer';
 export {
   getCurrentPageName,
+  getPlanCancel,
 } from './selectors';

--- a/src/core/dashboard/reducer.js
+++ b/src/core/dashboard/reducer.js
@@ -1,0 +1,25 @@
+import { createReducer } from 'redux-act';
+import { Record } from 'immutable';
+
+import {
+  confirmPlanCancel,
+  cancelPlanCancel,
+  // cancelPlan,
+} from './actions';
+
+const DashboardState = new Record({
+  confirmingPlanCancel: false,
+});
+
+export const dashboardReducer = createReducer({
+  [confirmPlanCancel]: (state) => (
+    state.merge({
+      confirmingPlanCancel: true,
+    })
+  ),
+  [cancelPlanCancel]: (state) => (
+    state.merge({
+      confirmingPlanCancel: false,
+    })
+  ),
+}, new DashboardState());

--- a/src/core/dashboard/selectors.js
+++ b/src/core/dashboard/selectors.js
@@ -13,3 +13,22 @@ export const getCurrentPageName = (state, ownProps) => {
   }
   return 'プラン情報';
 };
+
+export const getCurrentPageGroup = (state, ownProps) => {
+  const pathname = getLocation(state, ownProps).pathname;
+  if (/^\/dashboard\/grafana/.test(pathname)) {
+    return 'grafana';
+  }
+  if (/^\/dashboard\/influxdb/.test(pathname)) {
+    return 'influxdb';
+  }
+  return 'plan';
+};
+
+export const getPlanCancel = state => {
+  const { confirmingPlanCancel, cancelingPlan } = state.dashboard;
+  return {
+    confirmingPlanCancel,
+    cancelingPlan,
+  };
+};

--- a/src/core/reducers.js
+++ b/src/core/reducers.js
@@ -2,9 +2,11 @@ import { combineReducers } from 'redux';
 import { routerReducer } from 'react-router-redux';
 import { authReducer } from './auth';
 import { setupReducer } from './setup';
+import { dashboardReducer } from './dashboard';
 
 export default combineReducers({
   routing: routerReducer,
   auth: authReducer,
   setup: setupReducer,
+  dashboard: dashboardReducer,
 });

--- a/src/views/pages/dashboard/plan/index.css
+++ b/src/views/pages/dashboard/plan/index.css
@@ -22,3 +22,16 @@
 .price {
   margin-right: 3px;
 }
+
+.actions {
+  margin-top: 30px;
+}
+
+.cancel-message {
+  font-size: 0.9rem;
+  padding: 30px 0;
+}
+
+.support-email {
+  margin: 0 7px;
+}

--- a/src/views/pages/dashboard/plan/index.jsx
+++ b/src/views/pages/dashboard/plan/index.jsx
@@ -4,12 +4,16 @@ import { createSelector } from 'reselect';
 import { Grid, Row, Col } from 'react-flexbox-grid/lib/index';
 import Paper from 'material-ui/Paper';
 import { Table, TableBody, TableRow, TableRowColumn } from 'material-ui/Table';
+import Dialog from 'material-ui/Dialog';
+import FlatButton from 'material-ui/FlatButton';
 import { getPlanId } from 'src/core/auth';
 import { findPlan } from 'src/core/plans';
+import { getPlanCancel, dashboardActions } from 'src/core/dashboard';
+import { supportEmail } from 'src/core/common-info';
 
 import styles from './index.css';
 
-const Plan = ({ planId }) => {
+const Plan = ({ planId, confirmingPlanCancel, showCancelInformation, hideCancelInformation }) => {
   const plan = findPlan(planId);
   return (
     <div className={styles.whole}>
@@ -48,7 +52,30 @@ const Plan = ({ planId }) => {
                 </Table>
               </div>
             </Paper>
+            <div className={styles.actions}>
+              <FlatButton
+                label="プランの解約"
+                secondary
+                onClick={showCancelInformation}
+              />
+            </div>
           </Col>
+          {confirmingPlanCancel ?
+            <Dialog
+              title="プランの解約"
+              open={confirmingPlanCancel}
+              onRequestClose={hideCancelInformation}
+            >
+              <div className={styles['cancel-message']}>
+                プランの解約は
+                <a className={styles['support-email']} href={`mailto:${supportEmail}`}>
+                  {supportEmail}
+                </a>
+                までお問い合わせください。
+              </div>
+            </Dialog>
+            : null
+          }
         </Row>
       </Grid>
     </div>
@@ -57,11 +84,24 @@ const Plan = ({ planId }) => {
 
 Plan.propTypes = {
   planId: PropTypes.string.isRequired,
+  confirmingPlanCancel: PropTypes.bool,
+  showCancelInformation: PropTypes.func.isRequired,
+  hideCancelInformation: PropTypes.func.isRequired,
 };
 
 const mapStateToProps = createSelector(
   getPlanId,
-  (planId) => ({ planId }),
+  getPlanCancel,
+  (planId, { confirmingPlanCancel }) => ({ planId, confirmingPlanCancel }),
 );
 
-export default connect(mapStateToProps)(Plan);
+const mapDispatchToProps = (dispatch) => ({
+  showCancelInformation: () => {
+    dispatch(dashboardActions.confirmPlanCancel());
+  },
+  hideCancelInformation: () => {
+    dispatch(dashboardActions.cancelPlanCancel());
+  },
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(Plan);

--- a/src/views/pages/dashboard/server-setup/index.jsx
+++ b/src/views/pages/dashboard/server-setup/index.jsx
@@ -12,6 +12,7 @@ import {
   SERVER_SETUP_STATUS,
 } from 'src/core/server_setup';
 import { setupActions } from 'src/core/setup';
+import { supportEmail } from 'src/core/common-info';
 import styles from './index.css';
 
 class ServerSetup extends Component {
@@ -55,9 +56,8 @@ class ServerSetup extends Component {
                           Error Code: {errorCode}
                         </p>
                       </div>
-                      <a href="support@orangesys.io">support@orangesys.io</a> までお問い合わせください。
+                      <a href={supportEmail}>{supportEmail}</a> までお問い合わせください。
                     </div>
-
                   }
                 </div>
               </Paper>

--- a/src/views/pages/dashboard/server-setup/index.jsx
+++ b/src/views/pages/dashboard/server-setup/index.jsx
@@ -56,7 +56,7 @@ class ServerSetup extends Component {
                           Error Code: {errorCode}
                         </p>
                       </div>
-                      <a href={supportEmail}>{supportEmail}</a> までお問い合わせください。
+                      <a href={`mailto:${supportEmail}`}>{supportEmail}</a> までお問い合わせください。
                     </div>
                   }
                 </div>

--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -24,6 +24,7 @@ const ENV_NAMES = [
   'PAYMENT_API_ENDPOINT',
   'ORANGESYS_API_ENDPOINT',
   'SENTRY_DSN',
+  'SUPPORT_EMAIL',
 ];
 
 const ENV_DEVELOPMENT = NODE_ENV === 'development';


### PR DESCRIPTION
Resolves https://github.com/orangesys/app.orangesys.io/issues/34

最低限のボタンとサポートメールの表示を追加しました。

また、ENVで`SUPPORT_EMAIL`を指定できるようにしました。(デフォルトは`support@orangesys.io`なので指定しなくてもOK)

<img width="500" alt="orange_sys" src="https://cloud.githubusercontent.com/assets/4277693/21445101/453c9472-c8f8-11e6-91a7-30eb8127d655.png">
